### PR TITLE
Add an option to configure car-specific rims

### DIFF
--- a/CustomizeSub.h
+++ b/CustomizeSub.h
@@ -246,11 +246,23 @@ int __fastcall CustomizeSub_SetupAttachments(DWORD* _CustomizeSub, void* EDX_Unu
 
 void SetupRimBrandsHook(void* _CustomizeCategoryScreen)
 {
+    // Get CarType Info
+    void* FECarRecord = *(void**)_FECarRecord;
+    int CarTypeID = FECarRecord_GetType(FECarRecord);
+    sprintf(CarTypeName, GetCarTypeName(CarTypeID));
+
+    // Read Part Options for the car
+    sprintf(CarININame, "UnlimiterData\\%s.ini", CarTypeName);
+    CIniReader CarINI(CarININame);
+    CIniReader GeneralINI("UnlimiterData\\_General.ini");
+
+    int CarSpecificRims = CarINI.ReadInteger("Main", "CarSpecificRims", GeneralINI.ReadInteger("Main", "CarSpecificRims", 0));
+
     CIniReader RimBrandsINI("UnlimiterData\\_RimBrands.ini");
 
     int RimBrandsCount = RimBrandsINI.ReadInteger("RimBrands", "NumberOfRimBrands", -1);
 
-    for (int i = 0; i <= RimBrandsCount; i++)
+    for (int i = (CarSpecificRims != 0) ? 0 : 1; i <= RimBrandsCount; i++)
     {
         sprintf(RimBrandID, "Brand%d", i);
         sprintf(RimBrandIcon, RimBrandsINI.ReadString(RimBrandID, "Texture", ""));

--- a/UnlimiterData/_General.ini
+++ b/UnlimiterData/_General.ini
@@ -12,6 +12,7 @@
 [Main]
 ForceLODA = 0                   // Forces the highest LOD (A) for the car(s). Enable if your car(s) do(es)n't have LOD parts. (0 = False, 1 = True)
 EngineType = -1                 // Sets engine type to show proper performance upgrade names. (-1 = Not Set, 0 = Piston, 1 = Castrol, 2 = Rotary)
+CarSpecificRims = 0			 // If enabled, sets up "Custom" brand in Rims menu for car-specific rims. (0 = Disabled (Default), 1 = Enabled)
 
 [Parts]                         // PartLabel in Binary, GLOBAL\GlobalB.lzc, DBModelParts, CARNAME:
 BodyKits = 1                    // CARNAME_(KITxx_)BODY


### PR DESCRIPTION
Before that, "Custom" rim brand would always be available, even if there were no car-specific rims. In the perfect world it would be done via checking the existance of wheels in the geometry itself, but as Unlimiter allows for nearly any name for custom parts, it's not really possible to implement without setting a concrete rule for rim naming